### PR TITLE
Improve env handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # letter-reader
+
+This project is a Node.js server that analyzes letters or documents using OpenAI.
+
+## Environment Variables
+
+The server reads configuration from environment variables. When deploying to platforms such as Railway,
+set the following variables in your project settings:
+
+- `PORT` – Port the server should listen on.
+- `OPENAI_API_KEY` – API key for OpenAI.
+- `STRIPE_SECRET_KEY` – Stripe secret key for payments.
+- `STRIPE_WEBHOOK_SECRET` – Stripe webhook signing secret.
+- `DOMAIN` – Base URL for the frontend (used in payment redirects).
+- `MONGO_URL` or `MONGODB_URI` – MongoDB connection string.
+
+A local `.env` file can also be used for development. If the file does not exist,
+`server.js` will fall back to using the variables provided by the environment.

--- a/server.js
+++ b/server.js
@@ -10,7 +10,14 @@ const crypto = require("crypto")
 const pdf = require("pdf-parse")
 const sharp = require("sharp")
 const Tesseract = require("tesseract.js")
-require("dotenv").config()
+
+// Load environment variables from .env if present. When running on
+// platforms like Railway the variables are provided via process.env and
+// a local .env file may not exist.
+const dotenvResult = require("dotenv").config()
+if (dotenvResult.error) {
+  console.warn("No .env file found, relying on process environment variables")
+}
 
 const app = express()
 const PORT = process.env.PORT || 3000
@@ -21,6 +28,12 @@ const openai = new OpenAI({
 })
 
 const stripeClient = stripe(process.env.STRIPE_SECRET_KEY)
+
+// Support different environment variable names for the MongoDB connection.
+// Railway typically provides `MONGODB_URI` for its Mongo plugin. If `MONGO_URL`
+// is not defined we fall back to these alternatives.
+const MONGO_URL =
+  process.env.MONGO_URL || process.env.MONGODB_URI || process.env.MONGODB_URL
 
 // Middleware
 app.use(express.json({ limit: "50mb" }))
@@ -41,7 +54,7 @@ app.use((req, res, next) => {
 
 // MongoDB connection
 let db
-MongoClient.connect(process.env.MONGO_URL)
+MongoClient.connect(MONGO_URL)
   .then((client) => {
     console.log("Connected to MongoDB")
     db = client.db("letterreader")


### PR DESCRIPTION
## Summary
- update README with information about environment variables
- load `.env` only if present and add helpful warning
- support multiple environment variable names for MongoDB connection string

## Testing
- `node server.js` *(fails: Could not load the "sharp" module)*

------
https://chatgpt.com/codex/tasks/task_e_6840d1891c10832cb45c0601799005ed