### PR TITLE
Fix Stripe webhook and update pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # letter-reader
+
+This project is a Node.js server that analyzes letters or documents using OpenAI.
+
+## Environment Variables
+
+The server reads configuration from environment variables. When deploying to platforms such as Railway,
+set the following variables in your project settings:
+
+- `PORT` – Port the server should listen on.
+- `OPENAI_API_KEY` – API key for OpenAI.
+- `STRIPE_SECRET_KEY` – Stripe secret key for payments.
+- `STRIPE_WEBHOOK_SECRET` – Stripe webhook signing secret.
+- `DOMAIN` – Base URL for the frontend (used in payment redirects).
+- `MONGO_URL` or `MONGODB_URI` – MongoDB connection string.
+
+A local `.env` file can also be used for development. If the file does not exist,
+`server.js` will fall back to using the variables provided by the environment.
+
+## Token Pricing
+
+| Paquete de Tokens | Precio | Precio por Token | Ideal para... |
+| ----------------- | ------ | ---------------- | ------------- |
+| 5 tokens | $2.99 | $0.60 | pruebas / uso ocasional |
+| 10 tokens | $4.99 | $0.50 | uso moderado |
+| 25 tokens | $9.99 | $0.40 | usuarios frecuentes |
+| 50 tokens | $17.99 | $0.36 | negocios pequeños |
+| 100 tokens | $29.99 | $0.30 | uso intensivo / oficinas |

--- a/public/account.html
+++ b/public/account.html
@@ -512,33 +512,40 @@
         </p>
 
         <div class="token-packages">
-          <div class="token-package" onclick="selectPackage(1, 0.25)">
-            <h3>1 Token</h3>
-            <p style="font-size: 1.5rem; color: #4caf50; margin: 10px 0">
-              $0.25
-            </p>
-            <p style="color: #888">Perfect for trying out</p>
-          </div>
-          <div class="token-package" onclick="selectPackage(5, 1.00)">
+          <div class="token-package" onclick="selectPackage(5, 2.99)">
             <h3>5 Tokens</h3>
             <p style="font-size: 1.5rem; color: #4caf50; margin: 10px 0">
-              $1.00
+              $2.99
             </p>
-            <p style="color: #888">Save $0.25</p>
+            <p style="color: #888">$0.60 each</p>
           </div>
-          <div class="token-package" onclick="selectPackage(10, 1.75)">
+          <div class="token-package" onclick="selectPackage(10, 4.99)">
             <h3>10 Tokens</h3>
             <p style="font-size: 1.5rem; color: #4caf50; margin: 10px 0">
-              $1.75
+              $4.99
             </p>
-            <p style="color: #888">Save $0.75</p>
+            <p style="color: #888">$0.50 each</p>
           </div>
-          <div class="token-package" onclick="selectPackage(25, 4.00)">
+          <div class="token-package" onclick="selectPackage(25, 9.99)">
             <h3>25 Tokens</h3>
             <p style="font-size: 1.5rem; color: #4caf50; margin: 10px 0">
-              $4.00
+              $9.99
             </p>
-            <p style="color: #888">Save $2.25</p>
+            <p style="color: #888">$0.40 each</p>
+          </div>
+          <div class="token-package" onclick="selectPackage(50, 17.99)">
+            <h3>50 Tokens</h3>
+            <p style="font-size: 1.5rem; color: #4caf50; margin: 10px 0">
+              $17.99
+            </p>
+            <p style="color: #888">$0.36 each</p>
+          </div>
+          <div class="token-package" onclick="selectPackage(100, 29.99)">
+            <h3>100 Tokens</h3>
+            <p style="font-size: 1.5rem; color: #4caf50; margin: 10px 0">
+              $29.99
+            </p>
+            <p style="color: #888">$0.30 each</p>
           </div>
         </div>
 

--- a/server.js
+++ b/server.js
@@ -10,7 +10,14 @@ const crypto = require("crypto")
 const pdf = require("pdf-parse")
 const sharp = require("sharp")
 const Tesseract = require("tesseract.js")
-require("dotenv").config()
+
+// Load environment variables from .env if present. When running on
+// platforms like Railway the variables are provided via process.env and
+// a local .env file may not exist.
+const dotenvResult = require("dotenv").config()
+if (dotenvResult.error) {
+  console.warn("No .env file found, relying on process environment variables")
+}
 
 const app = express()
 const PORT = process.env.PORT || 3000
@@ -21,6 +28,58 @@ const openai = new OpenAI({
 })
 
 const stripeClient = stripe(process.env.STRIPE_SECRET_KEY)
+
+// Support different environment variable names for the MongoDB connection.
+// Railway typically provides `MONGODB_URI` for its Mongo plugin. If `MONGO_URL`
+// is not defined we fall back to these alternatives.
+const MONGO_URL =
+  process.env.MONGO_URL || process.env.MONGODB_URI || process.env.MONGODB_URL
+
+// Stripe webhook must be registered before body parsers so that we can access
+// the raw request body for signature verification.
+app.post("/webhook", express.raw({ type: "application/json" }), async (req, res) => {
+  const sig = req.headers["stripe-signature"]
+  let event
+
+  try {
+    event = stripeClient.webhooks.constructEvent(
+      req.body,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET,
+    )
+  } catch (err) {
+    console.error("Webhook signature verification failed:", err.message)
+    return res.status(400).send(`Webhook Error: ${err.message}`)
+  }
+
+  if (event.type === "checkout.session.completed") {
+    const session = event.data.object
+    const { email, tokens } = session.metadata
+
+    try {
+      const userId = generateUserId(email)
+      await db
+        .collection("users")
+        .updateOne({ userId }, { $inc: { tokens: Number.parseInt(tokens) } })
+
+      // Log the purchase
+      await db.collection("purchases").insertOne({
+        userId,
+        email,
+        tokens: Number.parseInt(tokens),
+        amount: session.amount_total / 100,
+        sessionId: session.id,
+        createdAt: new Date(),
+      })
+
+      console.log(`Added ${tokens} tokens to user ${email}`)
+    } catch (error) {
+      console.error("Error processing payment webhook:", error)
+    }
+  }
+
+  res.json({ received: true })
+})
 
 // Middleware
 app.use(express.json({ limit: "50mb" }))
@@ -41,7 +100,7 @@ app.use((req, res, next) => {
 
 // MongoDB connection
 let db
-MongoClient.connect(process.env.MONGO_URL)
+MongoClient.connect(MONGO_URL)
   .then((client) => {
     console.log("Connected to MongoDB")
     db = client.db("letterreader")
@@ -499,44 +558,6 @@ app.post("/api/create-payment", async (req, res) => {
   }
 })
 
-// Stripe webhook
-app.post("/webhook", express.raw({ type: "application/json" }), async (req, res) => {
-  const sig = req.headers["stripe-signature"]
-  let event
-
-  try {
-    event = stripeClient.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET)
-  } catch (err) {
-    console.error("Webhook signature verification failed:", err.message)
-    return res.status(400).send(`Webhook Error: ${err.message}`)
-  }
-
-  if (event.type === "checkout.session.completed") {
-    const session = event.data.object
-    const { email, tokens } = session.metadata
-
-    try {
-      const userId = generateUserId(email)
-      await db.collection("users").updateOne({ userId }, { $inc: { tokens: Number.parseInt(tokens) } })
-
-      // Log the purchase
-      await db.collection("purchases").insertOne({
-        userId,
-        email,
-        tokens: Number.parseInt(tokens),
-        amount: session.amount_total / 100,
-        sessionId: session.id,
-        createdAt: new Date(),
-      })
-
-      console.log(`Added ${tokens} tokens to user ${email}`)
-    } catch (error) {
-      console.error("Error processing payment webhook:", error)
-    }
-  }
-
-  res.json({ received: true })
-})
 
 // Health check
 app.get("/health", (req, res) => {


### PR DESCRIPTION
## Summary
- register Stripe webhook before body parsers so signature verification succeeds
- remove duplicate webhook handler
- update token purchase options in the account page
- document new pricing table in the README

## Testing
- `node server.js` *(fails: Could not load the "sharp" module)*

------
https://chatgpt.com/codex/tasks/task_e_6840d1891c10832cb45c0601799005ed